### PR TITLE
adding names to shiny app data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: EhdenAlopecia
 Title: Analytic software to perform large-scale distributed analysis of patients with Alopecia as part of the EHDEN study-athon
-Version: 1.2.2
+Version: 1.2.3
 Authors@R: person("Ross", "Williams", , "r.williams@derasmusmc.nl", role = c("aut", "cre"))
 Description: This package creates the cohorts for this EHDEN Alopecia study study. Based on this cohort diagnostics, incidence and prevalence rates and treatment patterns are analysis are performed.
 License: Apache License (>= 2)

--- a/R/runShinyAlopecia.R
+++ b/R/runShinyAlopecia.R
@@ -58,6 +58,15 @@ runShinyAlopecia <- function(resultsFolder = here::here("results")) {
                    targetCohort = targetCohortNumber[v]))
         }
       }
+      cohortNames <- read_csv(system.file("cohortDefinitionSet.csv", package = "EhdenAlopecia"), 
+                              show_col_types = FALSE,
+                              col_names = TRUE)
+      
+      resultsPathways <- resultsPathways %>%
+        mutate(path = ifelse(path %in% cohortNames$cohortId, cohortNames$cohortName[match(path, cohortNames$cohortId)], path),
+               targetCohort = ifelse(targetCohort %in% cohortNames$cohortId, cohortNames$cohortName[match(targetCohort, cohortNames$cohortId)], targetCohort))
+      
+      
       return(resultsPathways)
     })
     


### PR DESCRIPTION
- Shiny app matches the number of the cohorts, uses cohortdefinitionset from EdhenAPI to add the actual names of target and treatments, 